### PR TITLE
fix: upgrade axios to 1.13.3 for security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@types/node": "^25.0.8",
     "@vitest/coverage-v8": "^4.0.17",
     "@vitest/ui": "^4.0.17",
-    "axios": "^1.13.2",
+    "axios": "^1.13.3",
     "babel-loader": "^10.0.0",
     "busuanzi.pure.js": "^1.0.3",
     "canvas-confetti": "^1.9.3",


### PR DESCRIPTION
## 📝 PR 说明

### 修复内容
- **安全更新**: 将 axios 从 ^1.13.2 升级到 ^1.13.3，修复已知安全漏洞 (CVE)

### 检查清单
- [x] axios 依赖已更新
- [x] 需要运行 `pnpm install` 更新 lockfile

### 备注
这是依赖优化任务的第一个PR喵～ 🐱

后续还会有关于：
- vitepress 版本更新
- Java 项目 maven-shade-plugin 更新
等PR推送喵～