### PR TITLE
fix(ci): 修复 deploy 阶段 artifact 下载路径

### DIFF
--- a/.github/workflows/build-test-pull.yml
+++ b/.github/workflows/build-test-pull.yml
@@ -54,15 +54,18 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: site
+          path: ./
       - name: 部署
         uses: webfactory/ssh-agent@v0.5.3
         with:
           ssh-private-key: ${{ secrets.actions }}
       - run: |
           ssh-keyscan -H 110.42.45.207 >> ~/.ssh/known_hosts 2>/dev/null
+          scp -o StrictHostKeyChecking=no site.tar.gz root@110.42.45.207:/tmp/ &&
           ssh -o StrictHostKeyChecking=no root@110.42.45.207 "
             mkdir -p /www/MiragEdge/MiragEdge-DocWeb/build/miragedge.top/ &&
             rm -rf /www/MiragEdge/MiragEdge-DocWeb/build/miragedge.top/* &&
-            tar -xzf site.tar.gz -C /www/MiragEdge/MiragEdge-DocWeb/build/miragedge.top/ &&
+            tar -xzf /tmp/site.tar.gz -C /www/MiragEdge/MiragEdge-DocWeb/build/miragedge.top/ &&
+            rm /tmp/site.tar.gz &&
             echo 部署成功
           "


### PR DESCRIPTION
## 修复内容

**问题**: `download-artifact@v4` 默认下载到 `./site/` 目录，导致 `tar -xzf site.tar.gz` 找不到文件

**解决方案**: 
- 添加 `path: ./` 参数，让 artifact 下载到当前目录
- 使用 `scp` 先传输文件到远程再解压

## 变更文件
- `.github/workflows/build-test-pull.yml`

Closes #27