### PR TITLE
fix(ci): 延长超时到60分钟，优化部署脚本

### DIFF
--- a/.github/workflows/build-test-pull.yml
+++ b/.github/workflows/build-test-pull.yml
@@ -10,6 +10,7 @@ jobs:
   lint:
     name: 代码质量检查
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
@@ -24,6 +25,7 @@ jobs:
     name: 测试
     runs-on: ubuntu-latest
     needs: lint
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
@@ -49,6 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    timeout-minutes: 60
     steps:
       - name: 下载构建产物
         uses: actions/download-artifact@v4
@@ -59,13 +62,15 @@ jobs:
         uses: webfactory/ssh-agent@v0.5.3
         with:
           ssh-private-key: ${{ secrets.actions }}
-      - run: |
-          ssh-keyscan -H 110.42.45.207 >> ~/.ssh/known_hosts 2>/dev/null
-          scp -o StrictHostKeyChecking=no site.tar.gz root@110.42.45.207:/tmp/ &&
-          ssh -o StrictHostKeyChecking=no root@110.42.45.207 "
-            mkdir -p /www/MiragEdge/MiragEdge-DocWeb/build/miragedge.top/ &&
-            rm -rf /www/MiragEdge/MiragEdge-DocWeb/build/miragedge.top/* &&
-            tar -xzf /tmp/site.tar.gz -C /www/MiragEdge/MiragEdge-DocWeb/build/miragedge.top/ &&
-            rm /tmp/site.tar.gz &&
-            echo 部署成功
-          "
+      - name: 远程部署
+        run: |
+          set -e
+          ssh-keyscan -H 110.42.45.207 >> ~/.ssh/known_hosts 2>/dev/null || true
+          scp -o ConnectTimeout=60 -o StrictHostKeyChecking=no site.tar.gz root@110.42.45.207:/tmp/
+          ssh -o ConnectTimeout=60 -o StrictHostKeyChecking=no root@110.42.45.207 << 'ENDSSH'
+            mkdir -p /www/MiragEdge/MiragEdge-DocWeb/build/miragedge.top/
+            rm -rf /www/MiragEdge/MiragEdge-DocWeb/build/miragedge.top/*
+            tar -xzf /tmp/site.tar.gz -C /www/MiragEdge/MiragEdge-DocWeb/build/miragedge.top/
+            rm /tmp/site.tar.gz
+            echo "部署成功"
+          ENDSSH


### PR DESCRIPTION
## 修复内容

- **延长超时**: deploy 作业从默认超时延长到 60 分钟（国内服务器传输慢）
- **SSH 优化**: 添加 `ConnectTimeout=60` 防止连接超时
- **错误处理**: 添加 `set -e` 确保命令失败时退出

## 变更文件
- `.github/workflows/build-test-pull.yml`