### PR TITLE
fix(ci): 修复 contributors 和 lastUpdated 获取完整历史

### DIFF
--- a/.github/workflows/build-test-pull.yml
+++ b/.github/workflows/build-test-pull.yml
@@ -3,9 +3,17 @@ on: [push, pull_request]
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
+
+# 添加权限以获取完整历史
+permissions:
+  contents: read
+  pull-requests: read
+  actions: read
+
 env:
   NODE_VERSION: 22.x
   PNPM_VERSION: 10.15.0
+
 jobs:
   lint:
     name: 代码质量检查
@@ -13,6 +21,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # 获取完整 git 历史，用于 contributors 和 lastUpdated
       - uses: pnpm/action-setup@v2
         with:
           version: ${{ env.PNPM_VERSION }}
@@ -28,6 +38,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: pnpm/action-setup@v2
         with:
           version: ${{ env.PNPM_VERSION }}


### PR DESCRIPTION
## 修复内容

**问题**: 
- 贡献者组件只能获取到少量贡献者
- 页面更新时间显示不正确

**原因**: `actions/checkout@v4` 默认 `fetch-depth: 1`，只获取最新 commit，无法计算完整的贡献者历史

**解决方案**:
- 添加 `fetch-depth: 0` 获取完整 git 历史
- 添加 `permissions` 明确声明所需权限
- 在 lint 和 test 两个 job 的 checkout 步骤都添加

## 变更文件
- `.github/workflows/build-test-pull.yml`