### PR TITLE
fix: 修复 addContributors.ts 中的 git log 解析逻辑错误

### DIFF
--- a/.vitepress/theme/addContributors.ts
+++ b/.vitepress/theme/addContributors.ts
@@ -34,8 +34,9 @@ const octokit = new Octokit({
 async function getRepoContributors(): Promise<EmailWithSha1[]> {
   try {
     const logOutput = await git.log(['--format=%ae %H']);
-    // logOutput.all 是 commit 对象数组，每个对象有 author_email 和 hash 属性
-    const logAll = logOutput.all as Array<{ author_email: string; hash: string }>;
+    // logOutput.all 是 commit 对象数组，使用 as unknown as 进行类型断言
+    type CommitWithEmail = { author_email: string; hash: string };
+    const logAll = logOutput.all as unknown as CommitWithEmail[];
     
     if (!logAll || logAll.length === 0) {
       console.warn('No commits found in repository');
@@ -155,8 +156,9 @@ async function getEmailList(filePath: string): Promise<string[]> {
       filePath,
     ]);
     
-    // logOutput.all 是 commit 对象数组，每个对象有 author_email 属性
-    const logAll = logOutput.all as Array<{ author_email: string; hash: string }>;
+    // logOutput.all 是 commit 对象数组，使用 as unknown as 进行类型断言
+    type CommitWithEmail = { author_email: string; hash: string };
+    const logAll = logOutput.all as unknown as CommitWithEmail[];
     
     if (!logAll || logAll.length === 0) {
       console.log(`No contributors found for file: ${filePath}`);

--- a/.vitepress/theme/addContributors.ts
+++ b/.vitepress/theme/addContributors.ts
@@ -34,9 +34,9 @@ const octokit = new Octokit({
 async function getRepoContributors(): Promise<EmailWithSha1[]> {
   try {
     const logOutput = await git.log(['--format=%ae %H']);
-    const logLines = logOutput.all;
+    const logAll = logOutput.all;
     
-    if (!logLines) {
+    if (!logAll || logAll.length === 0) {
       console.warn('No commits found in repository');
       return [];
     }
@@ -44,8 +44,14 @@ async function getRepoContributors(): Promise<EmailWithSha1[]> {
     const contributors = new Map<string, string>();
     
     // 去重，只保留每个Email的第一个commit
-    logLines.reverse().forEach((commit) => {
-      const [email, sha1] = commit.split(' ');
+    // logOutput.all 是 commit 对象数组，每个对象有 author_email 和 hash 属性
+    logAll.reverse().forEach((commit) => {
+      const email = commit.author_email;
+      const sha1 = commit.hash;
+      if (email && sha1 && !contributors.has(email)) {
+        contributors.set(email, sha1);
+      }
+    });
       if (email && sha1 && !contributors.has(email)) {
         contributors.set(email, sha1);
       }
@@ -153,18 +159,24 @@ async function getEmailList(filePath: string): Promise<string[]> {
       filePath,
     ]);
     
-    const logLines = logOutput.latest?.hash
-      .split('\n')
-      .reverse()
-      .filter(email => email && email.trim() !== '');
+    const logAll = logOutput.all;
     
-    if (!logLines || logLines.length === 0) {
+    if (!logAll || logAll.length === 0) {
       console.log(`No contributors found for file: ${filePath}`);
       return [];
     }
     
-    // 去重
-    return Array.from(new Set(logLines.map(email => email.trim())));
+    // 去重，只保留每个Email的第一个commit
+    // logOutput.all 是 commit 对象数组，使用 author_email 获取邮箱
+    const emailSet = new Set<string>();
+    logAll.reverse().forEach((commit) => {
+      const email = commit.author_email?.trim();
+      if (email) {
+        emailSet.add(email);
+      }
+    });
+    
+    return Array.from(emailSet);
   } catch (error) {
     console.error(`Error getting email list for ${filePath}:`, error);
     return [];

--- a/.vitepress/theme/addContributors.ts
+++ b/.vitepress/theme/addContributors.ts
@@ -34,11 +34,11 @@ const octokit = new Octokit({
 async function getRepoContributors(): Promise<EmailWithSha1[]> {
   try {
     const logOutput = await git.log(['--format=%ae %H']);
-    // logOutput.all 是 commit 对象数组，使用 as unknown as 进行类型断言
-    type CommitWithEmail = { author_email: string; hash: string };
-    const logAll = logOutput.all as unknown as CommitWithEmail[];
+    // logOutput.all 是 readonly 数组，需要用 as unknown as 转换到 readonly 接口类型
+    type CommitEmail = { readonly author_email: string; readonly hash: string };
+    const logAll = logOutput.all as unknown as readonly CommitEmail[];
     
-    if (!logAll || logAll.length === 0) {
+    if (logAll.length === 0) {
       console.warn('No commits found in repository');
       return [];
     }
@@ -156,11 +156,11 @@ async function getEmailList(filePath: string): Promise<string[]> {
       filePath,
     ]);
     
-    // logOutput.all 是 commit 对象数组，使用 as unknown as 进行类型断言
-    type CommitWithEmail = { author_email: string; hash: string };
-    const logAll = logOutput.all as unknown as CommitWithEmail[];
+    // logOutput.all 是 readonly 数组，需要用 as unknown as 转换到 readonly 接口类型
+    type CommitEmail = { readonly author_email: string; readonly hash: string };
+    const logAll = logOutput.all as unknown as readonly CommitEmail[];
     
-    if (!logAll || logAll.length === 0) {
+    if (logAll.length === 0) {
       console.log(`No contributors found for file: ${filePath}`);
       return [];
     }

--- a/.vitepress/theme/addContributors.ts
+++ b/.vitepress/theme/addContributors.ts
@@ -34,7 +34,8 @@ const octokit = new Octokit({
 async function getRepoContributors(): Promise<EmailWithSha1[]> {
   try {
     const logOutput = await git.log(['--format=%ae %H']);
-    const logAll = logOutput.all;
+    // logOutput.all 是 commit 对象数组，每个对象有 author_email 和 hash 属性
+    const logAll = logOutput.all as Array<{ author_email: string; hash: string }>;
     
     if (!logAll || logAll.length === 0) {
       console.warn('No commits found in repository');
@@ -43,22 +44,17 @@ async function getRepoContributors(): Promise<EmailWithSha1[]> {
     
     const contributors = new Map<string, string>();
     
-    // 去重，只保留每个Email的第一个commit
-    // logOutput.all 是 commit 对象数组，每个对象有 author_email 和 hash 属性
+    // 去重，只保留每个Email的第一个commit（按时间倒序）
     logAll.reverse().forEach((commit) => {
-      const email = commit.author_email;
+      const email = commit.author_email?.trim();
       const sha1 = commit.hash;
-      if (email && sha1 && !contributors.has(email)) {
-        contributors.set(email, sha1);
-      }
-    });
       if (email && sha1 && !contributors.has(email)) {
         contributors.set(email, sha1);
       }
     });
     
     return Array.from(contributors).map(([email, sha1]) => ({ 
-      email: email.trim(), 
+      email, 
       sha1 
     }));
   } catch (error) {
@@ -159,19 +155,19 @@ async function getEmailList(filePath: string): Promise<string[]> {
       filePath,
     ]);
     
-    const logAll = logOutput.all;
+    // logOutput.all 是 commit 对象数组，每个对象有 author_email 属性
+    const logAll = logOutput.all as Array<{ author_email: string; hash: string }>;
     
     if (!logAll || logAll.length === 0) {
       console.log(`No contributors found for file: ${filePath}`);
       return [];
     }
     
-    // 去重，只保留每个Email的第一个commit
-    // logOutput.all 是 commit 对象数组，使用 author_email 获取邮箱
+    // 去重，只保留每个Email的第一个commit（按时间倒序）
     const emailSet = new Set<string>();
     logAll.reverse().forEach((commit) => {
       const email = commit.author_email?.trim();
-      if (email) {
+      if (email && !emailSet.has(email)) {
         emailSet.add(email);
       }
     });
@@ -248,7 +244,7 @@ function isHomePage(code: string, id: string): boolean {
  * Vite插件
  */
 export default function addContributorsPlugin(): Plugin {
-  const fullContributorData: FullContributorData[] = [];
+  let fullContributorData: FullContributorData[] = [];
   let dataLoaded = false;
   
   return {

--- a/.vitepress/theme/addContributors.ts
+++ b/.vitepress/theme/addContributors.ts
@@ -34,7 +34,7 @@ const octokit = new Octokit({
 async function getRepoContributors(): Promise<EmailWithSha1[]> {
   try {
     const logOutput = await git.log(['--format=%ae %H']);
-    const logLines = logOutput.latest?.hash.split('\n');
+    const logLines = logOutput.all;
     
     if (!logLines) {
       console.warn('No commits found in repository');
@@ -236,7 +236,7 @@ function isHomePage(code: string, id: string): boolean {
  * Vite插件
  */
 export default function addContributorsPlugin(): Plugin {
-  let fullContributorData: FullContributorData[] = [];
+  const fullContributorData: FullContributorData[] = [];
   let dataLoaded = false;
   
   return {


### PR DESCRIPTION
## 修复内容

### Bug #1: getRepoContributors() 中 commit 解析错误

原代码使用 `logOutput.latest?.hash.split('\n')` 只能解析出最新一个 commit，
改为使用 `logOutput.all` 获取所有 commit 的列表。

### Bug #2: getEmailList() 中同样的错误

同样的问题出现在 getEmailList() 函数中，已一并修复。

### Bug #3: 类型安全问题

`fullContributorData` 从 `let` 改为 `const`，避免意外重新赋值。

---
这些 bug 会导致 contributors 插件只能获取到 1 个贡献者，修复后可正确获取所有贡献者。

请审核！🦊