### PR TITLE
fix: 移除 CI 中 typecheck 失败被静默忽略的问题

### DIFF
--- a/.github/workflows/build-test-pull.yml
+++ b/.github/workflows/build-test-pull.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - run: pnpm install && pnpm run typecheck 2>&1 || echo "跳过"
+      - run: pnpm install && pnpm run typecheck
 
   test:
     name: 测试


### PR DESCRIPTION
## 修复内容

### CI typecheck 静默失败问题

```yaml
# ❌ 原错误：失败时打印"跳过"，CI 依然 success
- run: pnpm install && pnpm run typecheck 2>&1 || echo "跳过"

# ✅ 修复：移除 || echo "跳过"，让 CI 正确反映类型错误
- run: pnpm install && pnpm run typecheck
```

---
注：之前还发现了 Dark.ts 中 provide() 调用位置错误的问题，但那处修复需要更仔细地了解 VitePress 的实现细节才能正确修复。暂不包含在此 PR 中，后续单独处理。