### PR TITLE
fix(NodeStatus.vue): correct CSS flex layout for detail labels

### DIFF
--- a/.vitepress/theme/components/vue/NodeStatus.vue
+++ b/.vitepress/theme/components/vue/NodeStatus.vue
@@ -224,6 +224,7 @@ onUnmounted(() => {
   font-weight: bold;
   color: var(--vp-c-text-2);
   min-width: 70px;
+  flex: 0 0 auto;
 }
 
 .detail-value {

--- a/.vitepress/theme/components/vue/NodeStatus.vue
+++ b/.vitepress/theme/components/vue/NodeStatus.vue
@@ -224,7 +224,6 @@ onUnmounted(() => {
   font-weight: bold;
   color: var(--vp-c-text-2);
   min-width: 70px;
-  flex: 0 0 auto;
 }
 
 .detail-value {


### PR DESCRIPTION
## 修复内容

**文件：** 

**问题：**  缺少 ，导致标签列被错误拉伸，而  却设置为  延伸。

修复后：
-  → （固定宽度，不拉伸）
-  → （内容列延伸）

**修复前：**


**修复后：**
