### PR TITLE
fix: 修复 SEO meta 标签（og:url 域名错误、og:image 404、twitter 标签完善）

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -35,10 +35,11 @@ export default defineConfig({
     ['meta', { property: 'og:title', content: 'MiragEdge 文档中心' }],
     ['meta', { property: 'og:description', content: '锐界幻境 全方位的指南' }],
     ['meta', { property: 'og:type', content: 'website' }],
-    ['meta', { property: 'og:image', content: '/title_img/og-image.png' }],
-    ['meta', { property: 'og:url', content: 'https://docs.miraged.ge' }],
+    ['meta', { property: 'og:image', content: '/title_img/xingjiu.png' }],
+    ['meta', { property: 'og:url', content: 'https://miragedge.top' }],
     ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
-    ['meta', { name: 'twitter:creator', content: '@test_tool' }],
+    ['meta', { name: 'twitter:image', content: '/title_img/xingjiu.png' }],
+    ['meta', { name: 'twitter:creator', content: '@MiragEdge' }],
     // 百度站点验证（如果需要）
     // ['meta', { name: 'baidu-site-verification', content: 'code-xxxxxxxx' }],
     // 360站点验证（如果需要）


### PR DESCRIPTION
## 🔍 发现的问题

通过访问 https://miragedge.top/ 实际测试发现以下问题：

| 问题 | 修复前 | 修复后 |
|------|--------|--------|
| `og:url` 域名错误 | `https://docs.miraged.ge` | `https://miragedge.top` |
| `og:image` 404 | `/title_img/og-image.png`（文件不存在） | `/title_img/xingjiu.png` |
| `twitter:creator` 测试值 | `@test_tool` | `@MiragEdge` |
| 缺少 `twitter:image` | 无 | `/title_img/xingjiu.png` |

## 影响

- 社交分享（微信/QQ/Twitter）时预览图显示空白
- 点击预览跳转到错误域名
- Twitter 卡片无法正确显示图片

## 变更类型

- [x] 🐛 Bug 修复 (Bug Fix)

---

_锐界幻境 · MiragEdge — 星辰为引，梦魇为翼。_