### PR TITLE
fix: 首页英雄图片首次访问不显示（SPA hydration 时序问题）

### DIFF
--- a/index.md
+++ b/index.md
@@ -287,6 +287,32 @@ function animate() {
   ctx.globalCompositeOperation = 'source-over'
 }
 
+function findHeroImage() {
+  const selectors = [
+    '.VPHomeHero .VPImage img',
+    '.VPHomeHero img',
+    'main .VPImage img',
+    '[alt="MiragEdge"]'
+  ]
+  for (const selector of selectors) {
+    const found = document.querySelector(selector)
+    if (found) return found
+  }
+  return null
+}
+
+function replaceHeroImage(randomImage) {
+  const img = new Image()
+  img.onload = () => {
+    heroImage.src = randomImage
+    heroImage.alt = 'xingjiu'
+  }
+  img.onerror = () => {
+    console.warn('Failed to load hero image:', randomImage)
+  }
+  img.src = randomImage
+}
+
 onMounted(async () => {
   await nextTick()
   
@@ -296,31 +322,25 @@ onMounted(async () => {
   ]
   const randomImage = weightedImages[Math.floor(Math.random() * weightedImages.length)]
   
-  const selectors = [
-    '.VPHomeHero .VPImage img',
-    '.VPHomeHero img',
-    'main .VPImage img',
-    '[alt="MiragEdge"]'
-  ]
-  
-  for (const selector of selectors) {
-    const found = document.querySelector(selector)
-    if (found) {
-      heroImage = found
-      break
-    }
-  }
+  heroImage = findHeroImage()
   
   if (heroImage) {
-    const img = new Image()
-    img.onload = () => {
-      heroImage.src = randomImage
-      heroImage.alt = 'xingjiu'
-    }
-    img.onerror = () => {
-      console.warn('Failed to load hero image:', randomImage)
-    }
-    img.src = randomImage
+    replaceHeroImage(randomImage)
+  } else {
+    // VitePress hydration 可能还没完成，等待元素出现
+    let retries = 0
+    const maxRetries = 30
+    const observer = new MutationObserver(() => {
+      heroImage = findHeroImage()
+      if (heroImage || retries >= maxRetries) {
+        observer.disconnect()
+        if (heroImage) replaceHeroImage(randomImage)
+      }
+      retries++
+    })
+    observer.observe(document.body, { childList: true, subtree: true })
+    // 安全超时：3秒后停止观察
+    setTimeout(() => observer.disconnect(), 3000)
   }
   
   initStarEffect()


### PR DESCRIPTION
## 🐛 问题

首页英雄图片在首次访问时显示不出来，必须经过一次页面跳转后返回才能正常显示。

## 🔍 根因

VitePress 是 SPA，首次访问时的流程：

```
服务端渲染 HTML → 客户端加载 JS → hydration（水合）→ onMounted 触发
                                              ↑
                                    此时 DOM 可能还没完全就绪
                                    `.VPHomeHero .VPImage img` 选择器找不到元素
```

原代码在 `onMounted` 中只调用了 `await nextTick()`，但 VitePress 的 hydration 可能需要更长时间，导致选择器找不到 hero image 元素，图片替换静默失败。

跳转后返回时是客户端导航，组件重新挂载，DOM 已就绪，所以能正常显示。

## ✅ 修复

- 提取 `findHeroImage()` 函数，复用选择器逻辑
- 首次查找失败时，使用 `MutationObserver` 等待元素出现
- 设置 3 秒安全超时，避免内存泄漏

## 变更类型

- [x] 🐛 Bug 修复 (Bug Fix)

---

_锐界幻境 · MiragEdge — 星辰为引，梦魇为翼。_