### PR TITLE
fix: 英雄图片 v2 + README/build.bat 修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 ```bash
 Framework: VitePress 1.6.4
 Language: TypeScript 5.9.3
-Build: Node.js with optimized dependencies
+Build: pnpm + Node.js with optimized dependencies
 Visualization: Mermaid, Canvas-confetti
 ```
 
@@ -39,7 +39,7 @@ Visualization: Mermaid, Canvas-confetti
 - **@octokit/rest**: GitHub API客户端
 
 ## 🤝 贡献与支持
-- **GitHub仓库**：[fwindemiko/MiragEdge-DocWeb](https://github.com/fwindemiko/MiragEdge-DocWeb)
+- **GitHub仓库**：[FwindEmiko/MiragEdge-DocWeb](https://github.com/FwindEmiko/MiragEdge-DocWeb)
 - **提交问题**：访问GitHub仓库提交bug报告或功能建议
 - **开发文档**：查看[开发文档](/develop/index.md)了解插件开发与系统架构
 - **社区支持**：加入QQ群获取实时帮助

--- a/build.bat
+++ b/build.bat
@@ -7,7 +7,7 @@ echo 开始构建项目...
 echo ==============================================
 
 echo [1/2] 正在构建锐界幻境文档站项目...
-call npm run build
+call pnpm run build
 if !errorlevel! neq 0 (
     echo 锐界幻境文档站项目构建失败！
     pause

--- a/index.md
+++ b/index.md
@@ -114,7 +114,10 @@ features:
 </ClientOnly>
 
 <script setup>
-import { onMounted, onUnmounted, nextTick, ref } from 'vue'
+import { onMounted, onUnmounted, nextTick, ref, watch } from 'vue'
+import { useRouter } from 'vitepress'
+
+const { route } = useRouter()
 
 const images = [
   '/title_img/icon-1.png',
@@ -313,6 +316,23 @@ function replaceHeroImage(randomImage) {
   img.src = randomImage
 }
 
+function tryReplaceHeroImage(randomImage, attempt) {
+  // 查找 hero image：优先精确匹配，再模糊匹配
+  const精确选择器 = '.VPHomeHero .VPImage img'
+  const模糊选择器 = '.VPHomeHero img, main .VPImage img'
+  
+  let el = document.querySelector(精确选择器)
+  if (!el) el = document.querySelector(模糊选择器)
+  
+  // 确认找到的是 hero 图片（不是其他小图标）
+  if (el && el.naturalWidth > 100) {
+    heroImage = el
+    replaceHeroImage(randomImage)
+    return true
+  }
+  return false
+}
+
 onMounted(async () => {
   await nextTick()
   
@@ -322,28 +342,38 @@ onMounted(async () => {
   ]
   const randomImage = weightedImages[Math.floor(Math.random() * weightedImages.length)]
   
-  heroImage = findHeroImage()
-  
-  if (heroImage) {
-    replaceHeroImage(randomImage)
-  } else {
-    // VitePress hydration 可能还没完成，等待元素出现
-    let retries = 0
-    const maxRetries = 30
-    const observer = new MutationObserver(() => {
-      heroImage = findHeroImage()
-      if (heroImage || retries >= maxRetries) {
-        observer.disconnect()
-        if (heroImage) replaceHeroImage(randomImage)
-      }
-      retries++
-    })
-    observer.observe(document.body, { childList: true, subtree: true })
-    // 安全超时：3秒后停止观察
-    setTimeout(() => observer.disconnect(), 3000)
+  // 尝试立即替换
+  if (tryReplaceHeroImage(randomImage, 0)) {
+    initStarEffect()
+    return
   }
   
+  // VitePress hydration 可能还没完成，用轮询等待
+  let attempt = 0
+  const maxAttempts = 50
+  const interval = setInterval(() => {
+    attempt++
+    if (tryReplaceHeroImage(randomImage, attempt) || attempt >= maxAttempts) {
+      clearInterval(interval)
+    }
+  }, 100)
+  
+  // 安全超时：5秒后停止
+  setTimeout(() => clearInterval(interval), 5000)
+  
   initStarEffect()
+})
+
+// 路由变化时也重新替换图片
+watch(() => route.path, () => {
+  nextTick(() => {
+    const weightedImages = [
+      ...images.flatMap(img => Array(5).fill(img)),
+      hiddenImage
+    ]
+    const randomImage = weightedImages[Math.floor(Math.random() * weightedImages.length)]
+    tryReplaceHeroImage(randomImage, 0)
+  })
 })
 
 onUnmounted(() => {


### PR DESCRIPTION
## 📋 变更概览

### 1. 首页英雄图片修复 v2（`index.md`）

**问题**：首次访问时英雄图片不显示，需跳转后返回才正常。

**根因**：`onMounted` 在 VitePress SSR hydration 期间触发，此时 DOM 尚未就绪。之前的 MutationObserver 方案仍有缺陷——可能匹配到错误的 img 元素，或在 VitePress 二次渲染时被覆盖。

**v2 修复方案**：
- 使用 **100ms 轮询** 替代 MutationObserver，更可靠地等待元素出现
- **尺寸验证**：`el.naturalWidth > 100` 确认匹配的是 hero 大图而非小图标
- **路由监听**：`watch(route.path)` 在页面跳转时也重新替换图片
- **安全超时**：5 秒后停止轮询

### 2. `README.md`

- 技术栈 `Build: Node.js` → `Build: pnpm + Node.js`
- GitHub 仓库链接 `fwindemiko` → `FwindEmiko`（大小写修正）

### 3. `build.bat`

- `npm run build` → `pnpm run build`

## 变更类型

- [x] 🐛 Bug 修复 (Bug Fix)

---

_锐界幻境 · MiragEdge — 星辰为引，梦魇为翼。_