### PR TITLE
fix: MapIcon inline display — prevent text wrap after icon

### DIFF
--- a/.vitepress/theme/components/vue/MapIcon.vue
+++ b/.vitepress/theme/components/vue/MapIcon.vue
@@ -1,5 +1,7 @@
 <template>
-  <component :is="iconComponent" v-bind="attrs" v-on="$listeners" />
+  <span class="map-icon-wrapper">
+    <component :is="iconComponent" v-bind="attrs" v-on="$listeners" />
+  </span>
 </template>
 
 <script setup>

--- a/.vitepress/theme/css/icons.css
+++ b/.vitepress/theme/css/icons.css
@@ -118,3 +118,14 @@
 .VPSidebarItem .item .text {
   padding-left: 0;
 }
+
+/* MapIcon inline display fix */
+.map-icon-wrapper {
+  display: inline-flex;
+  align-items: center;
+  vertical-align: middle;
+}
+.map-icon-wrapper svg {
+  display: inline;
+  vertical-align: middle;
+}


### PR DESCRIPTION
修复 MapIcon 组件导致图标后文字换行的问题。

原因: Lucide SVG 默认渲染块级元素，导致图标后的文字被换到下一行。

修复:
- MapIcon.vue: 用 span 包裹图标组件
- icons.css: 添加 inline-flex 样式保证图标和文字同行居中对齐