### PR TITLE
fix: revert feature card icons back to emoji

### DIFF
--- a/index.md
+++ b/index.md
@@ -22,22 +22,22 @@ hero:
       link: /manual/qq_group
 
 features:
-  - icon: "<MapIcon name='gamepad' :size='28' />"
+  - icon: 🚢
     title: 创新玩法
     details: 独家轻 RPG 体系 × 星露谷田园 × 200+ 附魔 × 装备锻造，4 大维度交织出千人千面的冒险之旅
-  - icon: "<MapIcon name='server' :size='28' />"
+  - icon: 💾
     title: 高性能优化
     details: Leaf 服务端 + GraalVM 25 JIT 编译 + 全链路异步架构，TPS 稳定 20，告别卡顿掉帧
-  - icon: "<MapIcon name='heart' :size='28' />"
+  - icon: ❤️
     title: 优秀社区
     details: 公益纯净初心，7×24 管理守护，千人群组实时互动，从萌新到大佬都能找到归属
-  - icon: "<MapIcon name='tool' :size='28' />"
+  - icon: 🔧
     title: 稳定保障
     details: 长期开服零换档承诺，每日 4 次增量备份 + 异地容灾，Grim 反作弊 + 自动白名单双保险
-  - icon: "<MapIcon name='refresh-cw' :size='28' />"
+  - icon: 🔄
     title: 持续更新
     details: 周级迭代节奏，每月新增玩法与赛季活动，200+ 版本迭代持续打磨体验
-  - icon: "<MapIcon name='globe' :size='28' />"
+  - icon: 🌐
     title: 多端互通
     details: Java版 + 基岩版全平台支持，手机电脑均可畅玩，数据互通无缝衔接
 ---


### PR DESCRIPTION
首页 feature 卡片的 icon 字段是 YAML 字符串，不支持 Vue 组件渲染，所以 MapIcon 无法显示。

把6个卡片图标换回原本的 emoji:
- gamepad -> 🚢
- server -> 💾
- heart -> ❤️
- tool -> 🔧
- refresh-cw -> 🔄
- globe -> 🌐

内容区和导航/侧边栏的 MapIcon 不受影响，正常工作。