### PR TITLE
fix(todo): 新增优先级展示系统 — 徽章+主题色

### DIFF
--- a/.vitepress/theme/components/vue/TodoList.vue
+++ b/.vitepress/theme/components/vue/TodoList.vue
@@ -27,10 +27,18 @@ interface TodoItem {
   note?: string
 }
 
+interface PriorityDef {
+  label: string
+  color: string
+  bg: string
+  border: string
+}
+
 interface TodoGroup {
   key: string
   title: string
   subtitle?: string
+  priority?: string
   items: TodoItem[]
 }
 
@@ -39,6 +47,7 @@ interface TodoData {
   subtitle?: string
   categories: Record<string, { label: string; color: string }>
   statuses:   Record<string, { label: string; tone: string; icon: string }>
+  priorities?: Record<string, PriorityDef>
   groups:      TodoGroup[]
   completed:   TodoGroup[]
 }
@@ -80,6 +89,19 @@ const toggleNote = (id: string) => {
   if (next.has(id)) next.delete(id)
   else next.add(id)
   expandedNotes.value = next
+}
+
+/** 优先级徽章样式 */
+const getPriorityBadgeStyle = (priority?: string) => {
+  if (!priority || !data.value?.priorities?.[priority]) return {}
+  const p = data.value.priorities[priority]
+  return { color: p.color, background: p.bg, borderColor: p.border }
+}
+
+/** 分组头部下划线颜色 = 优先级色 */
+const getPriorityBorderStyle = (priority?: string) => {
+  if (!priority || !data.value?.priorities?.[priority]) return {}
+  return { borderBottomColor: data.value.priorities[priority].border }
 }
 
 /** 状态 tone → 颜色 token */
@@ -175,7 +197,12 @@ const totalItemsCount = computed(() => {
 
       <!-- 待完成 -->
       <section v-for="group in filteredGroups" :key="`p-${group.key}`" class="todo-section">
-        <header class="todo-section-head">
+        <header class="todo-section-head" :style="getPriorityBorderStyle(group.priority)">
+          <span
+            v-if="group.priority && data?.priorities?.[group.priority]"
+            class="todo-priority-badge"
+            :style="getPriorityBadgeStyle(group.priority)"
+          >{{ data.priorities[group.priority].label }}</span>
           <h3 class="todo-section-title">{{ group.title }}</h3>
           <span v-if="group.subtitle" class="todo-section-sub">{{ group.subtitle }}</span>
         </header>
@@ -675,6 +702,22 @@ const totalItemsCount = computed(() => {
   .todo-section-title {
     font-size: 16px;
   }
+}
+
+/* 优先级徽章 */
+.todo-priority-badge {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 10px;
+  border-radius: 20px;
+  border-width: 1px;
+  border-style: solid;
+  letter-spacing: 1px;
+  white-space: nowrap;
+  text-transform: uppercase;
 }
 
 /* 减少动效 */

--- a/public/data/todo.json
+++ b/public/data/todo.json
@@ -2,19 +2,58 @@
   "version": "2026.07.13",
   "subtitle": "F.windEmiko 的开发待办面板。条目长期滚动保留；完成 15 天后归档到 /develop/logs。",
   "categories": {
-    "添加": { "label": "添加", "color": "#22c55e" },
-    "调整": { "label": "调整", "color": "#3b82f6" },
-    "修复": { "label": "修复", "color": "#ef4444" },
-    "升级": { "label": "升级", "color": "#a855f7" },
-    "兼容": { "label": "兼容", "color": "#06b6d4" }
+    "添加": {
+      "label": "添加",
+      "color": "#22c55e"
+    },
+    "调整": {
+      "label": "调整",
+      "color": "#3b82f6"
+    },
+    "修复": {
+      "label": "修复",
+      "color": "#ef4444"
+    },
+    "升级": {
+      "label": "升级",
+      "color": "#a855f7"
+    },
+    "兼容": {
+      "label": "兼容",
+      "color": "#06b6d4"
+    }
   },
   "statuses": {
-    "待开始":    { "label": "待开始",   "tone": "neutral", "icon": "·" },
-    "进行中":    { "label": "进行中",   "tone": "active",  "icon": "›" },
-    "等待验收":  { "label": "等待验收", "tone": "warn",    "icon": "…" },
-    "卡住":      { "label": "卡住",     "tone": "danger",  "icon": "!" },
-    "构思中":    { "label": "构思中",   "tone": "think",   "icon": "?" },
-    "已完成":    { "label": "已完成",   "tone": "done",    "icon": "✓" }
+    "待开始": {
+      "label": "待开始",
+      "tone": "neutral",
+      "icon": "·"
+    },
+    "进行中": {
+      "label": "进行中",
+      "tone": "active",
+      "icon": "›"
+    },
+    "等待验收": {
+      "label": "等待验收",
+      "tone": "warn",
+      "icon": "…"
+    },
+    "卡住": {
+      "label": "卡住",
+      "tone": "danger",
+      "icon": "!"
+    },
+    "构思中": {
+      "label": "构思中",
+      "tone": "think",
+      "icon": "?"
+    },
+    "已完成": {
+      "label": "已完成",
+      "tone": "done",
+      "icon": "✓"
+    }
   },
   "groups": [
     {
@@ -58,7 +97,8 @@
           "status": "待开始",
           "note": "方块存入/取出价值表、稀有方块兑换率、通胀控制策略设计"
         }
-      ]
+      ],
+      "priority": "high"
     },
     {
       "key": "mid-system",
@@ -110,7 +150,8 @@
           "status": "待开始",
           "note": "提取数据包内嵌材质，合并到主材质包中，确保基岩版玩家可见"
         }
-      ]
+      ],
+      "priority": "medium"
     },
     {
       "key": "low-content",
@@ -189,7 +230,8 @@
           "status": "待开始",
           "note": "食用后 5 秒内消耗一整条饥饿条；饥饿系统调试 / 表演用。"
         }
-      ]
+      ],
+      "priority": "low"
     }
   ],
   "completed": [
@@ -247,5 +289,25 @@
         }
       ]
     }
-  ]
+  ],
+  "priorities": {
+    "high": {
+      "label": "高优先级",
+      "color": "#ef4444",
+      "bg": "rgba(239,68,68,0.08)",
+      "border": "rgba(239,68,68,0.25)"
+    },
+    "medium": {
+      "label": "中优先级",
+      "color": "#f59e0b",
+      "bg": "rgba(245,158,11,0.08)",
+      "border": "rgba(245,158,11,0.25)"
+    },
+    "low": {
+      "label": "低优先级",
+      "color": "#6b7280",
+      "bg": "rgba(107,114,128,0.08)",
+      "border": "rgba(107,114,128,0.25)"
+    }
+  }
 }


### PR DESCRIPTION
### 修复内容

合并 PR #76 后待办页仍有两个问题：
1. **无优先级展示** — 组件缺少视觉优先级逻辑
2. **数据缺 priority 字段** — todo.json 有 3 个分组但没有优先级标记

### 数据变更
- : 3 个分组新增  字段（high/medium/low）
- 新增  定义（颜色/标签/背景色）

### 组件变更
- 新增  接口、 字段到 
- 新增  和  渲染方法
- 每个分组头部新增 **优先级徽章**（红/黄/灰三色）
- 分组下划线颜色跟随优先级

### 视觉效果
- 🔴 **高优先级** → 红色徽章 + 红色下划线
- 🟡 **中优先级** → 黄色徽章 + 黄色下划线
- ⚪ **低优先级** → 灰色徽章 + 灰色下划线