### PR TITLE
fix(ci): 修复 fork PR 下 vars 判断导致预览部署被跳过

### DIFF
--- a/.github/workflows/build-test-pull.yml
+++ b/.github/workflows/build-test-pull.yml
@@ -124,7 +124,7 @@ jobs:
     name: 预览部署 (Cloudflare Pages)
     runs-on: ubuntu-22.04
     needs: lint
-    if: ${{ github.event_name == 'pull_request' && vars.CF_PAGES_PROJECT != '' }}
+    if: github.event_name == 'pull_request'
     continue-on-error: true
     timeout-minutes: 15
     steps:
@@ -146,9 +146,10 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          command: pages deploy .vitepress/dist --project-name=${{ vars.CF_PAGES_PROJECT }}
+          command: pages deploy .vitepress/dist --project-name=miragedge-docweb
 
       - name: 展示预览地址到 Actions 结果
+        if: steps.cloudflare.outcome == 'success'
         run: |
           echo "## :cloud: Cloudflare Pages 预览" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-test-pull.yml
+++ b/.github/workflows/build-test-pull.yml
@@ -124,7 +124,7 @@ jobs:
     name: 预览部署 (Cloudflare Pages)
     runs-on: ubuntu-22.04
     needs: lint
-    if: github.event_name == 'pull_request' && vars.CF_PAGES_PROJECT != ''
+    if: ${{ github.event_name == 'pull_request' && vars.CF_PAGES_PROJECT != '' }}
     continue-on-error: true
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## 问题

fork PR 触发的 CI 中 preview 任务被跳过（skipped），即使 CF_PAGES_PROJECT 变量已在仓库中正确配置。

## 原因

当 PR 来自 fork（FCelestial）时，job-level 的 if 条件中 vars 上下文的解析行为存在差异，导致条件始终为 false。

## 修复

使用 dollar-braces 表达式显式包裹条件，确保在运行时正确求值。