### PR TITLE
feat(ci): dev 分支推送 + PR 均触发预览部署

### DIFF
--- a/.github/workflows/build-test-pull.yml
+++ b/.github/workflows/build-test-pull.yml
@@ -124,7 +124,7 @@ jobs:
     name: 预览部署 (Cloudflare Pages)
     runs-on: ubuntu-22.04
     needs: lint
-    if: github.event_name == 'pull_request' && vars.CF_PAGES_PROJECT != ''
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/dev'
     continue-on-error: true
     timeout-minutes: 15
     steps:
@@ -146,9 +146,10 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          command: pages deploy .vitepress/dist --project-name=${{ vars.CF_PAGES_PROJECT }}
+          command: pages deploy .vitepress/dist --project-name=miragedge-docweb
 
       - name: 展示预览地址到 Actions 结果
+        if: steps.cloudflare.outcome == 'success'
         run: |
           echo "## :cloud: Cloudflare Pages 预览" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## 改动内容

1. dev 分支策略: 新建设 dev 分支，push 到 dev 自动触发 Cloudflare Pages 预览
2. 预览条件扩展: 改为 pull_request 或 push 到 dev 时触发
3. 修复 fork 兼容: 移除 vars 条件依赖，硬编码项目名 miragedge-docweb
4. 兜底保护: continue-on-error + outcome 检查，失败不影响整体 CI

## 工作流

  git checkout -b feat/xxx
  开发...
  git push upstream feat/xxx
  自动预览

  测试无误后合并到 dev
  git checkout dev && git merge feat/xxx && git push upstream dev
  预览再次更新，确认合并结果

  最后开 PR: dev  main
  生产站更新
