### PR TITLE
refactor(ci): 拆分预览部署为独立的 preview.yml

### DIFF
--- a/.github/workflows/build-test-pull.yml
+++ b/.github/workflows/build-test-pull.yml
@@ -79,6 +79,7 @@ jobs:
 
   # ============================================================
   # 生产部署 (ECS)
+  # 仅当 push 到 main 分支时触发
   # ============================================================
   deploy:
     name: 部署
@@ -112,47 +113,3 @@ jobs:
             rm /tmp/site.tar.gz
             echo "✅ 部署成功"
           ENDSSH
-
-  # ============================================================
-  # 预览部署 (Cloudflare Pages)
-  # 前提: 在 GitHub 仓库 Settings → Secrets and variables →
-  #       Actions → Variables 中设置 CF_PAGES_PROJECT
-  #       在 Secrets 中设置 CLOUDFLARE_API_TOKEN
-  #       未配置时自动跳过，不影响现有流程
-  # ============================================================
-  preview:
-    name: 预览部署 (Cloudflare Pages)
-    runs-on: ubuntu-22.04
-    needs: lint
-    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/dev'
-    continue-on-error: true
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: pnpm/action-setup@v2
-        with:
-          version: ${{ env.PNPM_VERSION }}
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - run: pnpm install
-      - run: pnpm run build
-
-      - name: 部署到 Cloudflare Pages
-        id: cloudflare
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          command: pages deploy .vitepress/dist --project-name=miragedge-docweb
-
-      - name: 展示预览地址到 Actions 结果
-        if: steps.cloudflare.outcome == 'success'
-        run: |
-          echo "## :cloud: Cloudflare Pages 预览" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **预览地址**: [${{ steps.cloudflare.outputs.deployment-url }}](${{ steps.cloudflare.outputs.deployment-url }})" >> $GITHUB_STEP_SUMMARY
-          echo "- **分支**: ${{ github.head_ref }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **PR**: [#${{ github.event.number }}](${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.number }})" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,56 @@
+name: 预览部署 (Cloudflare Pages)
+
+# 仅在 push 到上游 dev 分支时触发
+# PR 和 fork 仓库自然排除——因为 on: push 不会响应 PR 事件
+on:
+  push:
+    branches:
+      - dev
+
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: 22.x
+  PNPM_VERSION: 10.15.0
+
+jobs:
+  preview:
+    name: 预览部署 (Cloudflare Pages)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - run: pnpm install
+      - run: pnpm run build
+
+      - name: 部署到 Cloudflare Pages
+        id: cloudflare
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          command: pages deploy .vitepress/dist --project-name=miragedge-docweb
+
+      - name: 展示预览地址
+        if: steps.cloudflare.outcome == 'success'
+        run: |
+          echo "## :cloud: Cloudflare Pages 预览" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **预览地址**: [${{ steps.cloudflare.outputs.deployment-url }}](${{ steps.cloudflare.outputs.deployment-url }})" >> $GITHUB_STEP_SUMMARY
+          echo "- **分支**: ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **提交**: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

将 Cloudflare Pages 预览部署从 build-test-pull.yml 拆分为独立工作流。

## 变更

### 新增 preview.yml（独立预览工作流）
- 仅在 push 到 upstream dev 分支时触发
- PR / fork 仓库**自然排除**——on: push 不响应 PR 事件
- 不再需要 continue-on-error 或复杂的条件判断
- concurrency 避免并发部署冲突

### 精简 build-test-pull.yml
- 移除 preview job（共 44 行），保留 lint + build + deploy
- deploy 仅 push main 触发，不变

## CI 触发总览

| 事件 | lint | build | preview | deploy |
|------|------|-------|---------|--------|
| feat/* push | ✅ | ✅ | ❌ | ❌ |
| dev push | ✅ | ✅ | ✅ | ❌ |
| PR | ✅ | ✅ | ❌ | ❌ |
| fork PR | ✅ | ✅ | ❌ | ❌ |
| main push | ✅ | ✅ | ❌ | ✅ |

## Verification
- feat/ci-split-preview 已推 upstream ✅
- dev 已推 upstream ✅
- preview.yml 仅监听 dev push ✅

🤖 Generated with Hermes Agent
Co-authored-by: F.windEmiko <2011857087@qq.com>
