### PR TITLE
refactor(ci): CI/CD 仅在 main push 触发，dev 由 Pages 自动预览

### DIFF
--- a/.github/workflows/build-test-pull.yml
+++ b/.github/workflows/build-test-pull.yml
@@ -1,6 +1,9 @@
 name: CI/CD 持续集成
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
## Summary

CI/CD 仅在 main push 触发。dev/feat 分支和 PR 不再运行 lint/build。

## 变更

- on: [push, pull_request] → on: push: branches: [main]
- dev 推送零 CI 运行，预览由 Cloudflare Pages Git 集成自动处理

## 最终触发一览

| 事件 | CI (lint+build+deploy) | 预览 |
|------|----------------------|------|
| feat/* push | ❌ | Cloudflare Pages |
| dev push | ❌ | Cloudflare Pages |
| PR | ❌ | — |
| main push | ✅ (含 deploy) | — |

🤖 Generated with Hermes Agent
Co-authored-by: F.windEmiko <2011857087@qq.com>
