### PR TITLE
CI/CD 最终版: Actions 仅 main 部署，预览由 Cloudflare Pages App 自动处理

### DIFF
--- a/.github/workflows/build-test-pull.yml
+++ b/.github/workflows/build-test-pull.yml
@@ -1,6 +1,9 @@
 name: CI/CD 持续集成
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
## Summary

CI/CD 最终版：GitHub Actions 仅处理 main 生产部署，预览由 Cloudflare Pages GitHub App 自动完成。

## 变更

- build-test-pull.yml: on: push: branches: [main]
- preview.yml 已删除
- dev/feat/PR 均不触发 GitHub Actions

## 架构

| 阶段 | 触发 | 处理者 |
|------|------|--------|
| dev 预览 | push to dev | Cloudflare Pages GitHub App (自动) |
| 生产部署 | push to main | GitHub Actions (build-test-pull.yml) |

> Cloudflare Pages GitHub App 是连接仓库时自动安装的机器人，
> 每次 push 到任何分支都会自动构建生成预览链接。
> 比 wrangler-action 更干净——无需 token、无需 YAML 配置。

🤖 Generated with Hermes Agent
