### PR TITLE
fix(deps): bump vite to ^6.4.3 (fix 3 dependabot alerts)

### DIFF
--- a/.vitepress/theme/components/vue/GithubRepoActivity.vue
+++ b/.vitepress/theme/components/vue/GithubRepoActivity.vue
@@ -61,6 +61,19 @@ interface WeekData {
   shortLabel: string; commits: number; percent: number
 }
 
+const CONTRIBUTOR_COLORS = [
+  "#4CAF50", "#2196F3", "#FF9800", "#9C27B0",
+  "#F44336", "#00BCD4", "#FF5722", "#3F51B5",
+]
+
+interface SegmentData {
+  login: string; commits: number; barPx: number; color: string
+}
+
+interface ContributorData {
+  login: string; totalCommits: number; color: string
+}
+
 const loading = ref(true)
 const error = ref(false)
 const rawData = ref<RawWeek[]>([])

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "terser": "^5.44.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3",
-    "vite": "^5.4.0",
+    "vite": "^6.4.3",
     "vitepress": "^1.6.4",
     "vitepress-plugin-mermaid": "^2.0.17",
     "vitepress-sidebar": "^1.31.0",


### PR DESCRIPTION

Fixes 3 Dependabot alerts on the **dev** branch:

| # | 漏洞 | CVSS v4 | 修复版本 |
|---|------|---------|---------|
| #78 | .map 路径穿越 (CVE-2026-39365) | 6.3 (Medium) | vite ≥ 6.4.2 |
| #79 | fs.deny Windows 绕过 (CVE-2026-53571) | 8.2 (High) | vite ≥ 6.4.3 |
| #80 | launch-editor NTLM hash 泄露 (CVE-2026-53632) | 5.5 (Medium) | vite ≥ 6.4.3 |

**变更**:  → 

（pnpm-lock.yaml 在 .gitignore 中，无需提交）
