### PR TITLE
fix: resolve vite 6 typecheck errors in CI

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -65,8 +65,8 @@ export default defineConfig({
       __BUILD_SHA__: JSON.stringify(process.env.GITHUB_SHA ? process.env.GITHUB_SHA.substring(0, 7) : ''),
     },
     plugins: [
-      MermaidPlugin(),
-      addContributorsPlugin(),
+      MermaidPlugin() as any,
+      addContributorsPlugin() as any,
     ],
     optimizeDeps: {
       include: ['mermaid', 'vue']

--- a/.vitepress/theme/components/vue/GithubRepoActivity.vue
+++ b/.vitepress/theme/components/vue/GithubRepoActivity.vue
@@ -97,10 +97,6 @@ const controller = new AbortController()
 
 
 const MAX_BAR_PX = 120
-const CONTRIBUTOR_COLORS = [
-  "#4CAF50", "#2196F3", "#FF9800", "#9C27B0",
-  "#F44336", "#00BCD4", "#FF5722", "#3F51B5",
-]
 
 
 const chartData = computed<WeekData[]>(() => {


### PR DESCRIPTION
Fix typecheck error caused by vite 6.x type system:

config.mts: cast MermaidPlugin() and addContributorsPlugin() as any
to resolve Plugin<any> PluginOption type conflict.

Verified: typecheck + build both pass.