### PR TITLE
chore: sync dev into main

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -65,8 +65,8 @@ export default defineConfig({
       __BUILD_SHA__: JSON.stringify(process.env.GITHUB_SHA ? process.env.GITHUB_SHA.substring(0, 7) : ''),
     },
     plugins: [
-      MermaidPlugin(),
-      addContributorsPlugin(),
+      MermaidPlugin() as any,
+      addContributorsPlugin() as any,
     ],
     optimizeDeps: {
       include: ['mermaid', 'vue']

--- a/.vitepress/theme/components/vue/GithubRepoActivity.vue
+++ b/.vitepress/theme/components/vue/GithubRepoActivity.vue
@@ -97,10 +97,6 @@ const controller = new AbortController()
 
 
 const MAX_BAR_PX = 120
-const CONTRIBUTOR_COLORS = [
-  "#4CAF50", "#2196F3", "#FF9800", "#9C27B0",
-  "#F44336", "#00BCD4", "#FF5722", "#3F51B5",
-]
 
 
 const chartData = computed<WeekData[]>(() => {

--- a/.vitepress/theme/components/vue/GithubRepoActivity.vue
+++ b/.vitepress/theme/components/vue/GithubRepoActivity.vue
@@ -61,6 +61,19 @@ interface WeekData {
   shortLabel: string; commits: number; percent: number
 }
 
+const CONTRIBUTOR_COLORS = [
+  "#4CAF50", "#2196F3", "#FF9800", "#9C27B0",
+  "#F44336", "#00BCD4", "#FF5722", "#3F51B5",
+]
+
+interface SegmentData {
+  login: string; commits: number; barPx: number; color: string
+}
+
+interface ContributorData {
+  login: string; totalCommits: number; color: string
+}
+
 const loading = ref(true)
 const error = ref(false)
 const rawData = ref<RawWeek[]>([])

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "terser": "^5.44.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3",
-    "vite": "^5.4.0",
+    "vite": "^6.4.3",
     "vitepress": "^1.6.4",
     "vitepress-plugin-mermaid": "^2.0.17",
     "vitepress-sidebar": "^1.31.0",


### PR DESCRIPTION
将 dev 分支的最新变更同步到 main：

- PR #95: 升级 vite ^5.4.0 → ^6.4.3（修复 3 个 Dependabot 安全告警）
- PR #97: 修复 vite 6 类型错误（Plugin any cast + CONTRIBUTOR_COLORS 重复声明清理）

合并后 main 将部署到生产环境。