### PR TITLE
fix: 仓库活跃度数据生成 — gh auth token fallback + 202 重试

### DIFF
--- a/.vitepress/theme/addContributors.ts
+++ b/.vitepress/theme/addContributors.ts
@@ -4,6 +4,7 @@ import { Octokit } from '@octokit/rest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as dotenv from 'dotenv';
+import { execSync } from "child_process";
 
 // 加载环境变量
 dotenv.config();
@@ -237,9 +238,29 @@ async function fetchAndSaveActivityData(): Promise<void> {
     fs.mkdirSync(dir, { recursive: true });
   }
   try {
-    const resp = await octokit.request("GET /repos/{owner}/{repo}/stats/contributors", { owner, repo });
-    if (resp.status === 200 && Array.isArray(resp.data)) {
-      const simplified = resp.data.map((contrib: any) => ({
+    // Get token from env or fallback to gh CLI (local dev)
+    let token = process.env.GITHUB_TOKEN;
+    if (!token) {
+      try {
+        token = execSync('gh auth token', { encoding: 'utf-8' }).trim();
+      } catch { /* gh not available, will try unauthenticated */ }
+    }
+    const localApi = token
+      ? new Octokit({ auth: token })
+      : octokit;
+    // GitHub stats endpoint returns 202 while generating cache — retry up to 5x
+    let data: any = null;
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const resp = await localApi.request("GET /repos/{owner}/{repo}/stats/contributors", { owner, repo });
+      if (resp.status === 200 && Array.isArray(resp.data)) {
+        data = resp.data;
+        break;
+      }
+      console.log("[activity] Attempt " + (attempt + 1) + " got " + resp.status + ", retrying in 3s...");
+      await new Promise(r => setTimeout(r, 3000));
+    }
+    if (data) {
+      const simplified = data.map((contrib: any) => ({
         author: { login: contrib.author.login },
         total: contrib.total,
         weeks: contrib.weeks.map((w: any) => ({ w: w.w, c: w.c })),
@@ -247,7 +268,7 @@ async function fetchAndSaveActivityData(): Promise<void> {
       fs.writeFileSync(outputPath, JSON.stringify(simplified), "utf-8");
       console.log("[activity] Saved " + simplified.length + " contributors");
     } else {
-      console.warn("[activity] API status " + resp.status + ", fallback");
+      console.warn("[activity] All 5 attempts failed, writing empty data");
       fs.writeFileSync(outputPath, JSON.stringify([]), "utf-8");
     }
   } catch (error) {


### PR DESCRIPTION
## 问题

team.html 底部「GitHub 仓库活跃度」显示 ⚠ 暂时无法获取仓库活跃数据

## 根因

1. addContributors.ts 中 fetchAndSaveActivityData 使用 Octokit 请求 GitHub API，但 GITHUB_TOKEN 未设置（本地无 .env 文件），导致未认证请求
2. GitHub /repos/{owner}/{repo}/stats/contributors 在缓存未就绪时返回 202 Accepted，原代码只处理 200，其余状态一律当失败处理

## 修复

1. Token fallback: 优先读 GITHUB_TOKEN 环境变量，不存在则通过 execSync(gh auth token) 获取本地 gh CLI 的认证 token
2. 202 重试: 最多 5 次轮询，间隔 3 秒，直到收到 200

## 验证

本地构建日志:
[activity] Attempt 1 got 202, retrying in 3s...
[activity] Saved 5 contributors

数据文件从空 [] 更新为 5 位贡献者共计 510 次提交。