### PR TITLE
fix(ci): 仓库活跃度改用本地 git log 生成，不再依赖 GitHub API

### DIFF
--- a/.vitepress/theme/addContributors.ts
+++ b/.vitepress/theme/addContributors.ts
@@ -25,8 +25,12 @@ const repo = 'MiragEdge-DocWeb'; // 你的仓库名
 
 // 初始化
 const git = simpleGit();
+let ghToken = process.env.GITHUB_TOKEN;
+if (!ghToken) {
+  try { ghToken = execSync('gh auth token', { encoding: 'utf-8' }).trim(); } catch {}
+}
 const octokit = new Octokit({
-  auth: process.env.GITHUB_TOKEN,
+  auth: ghToken,
 });
 
 /**
@@ -231,49 +235,91 @@ function isHomePage(code: string, id: string): boolean {
 /**
  * 获取仓库提交活跃数据并保存为静态JSON
  */
-async function fetchAndSaveActivityData(): Promise<void> {
+async function fetchAndSaveActivityData(emailMap: Record<string, string>): Promise<void> {
   const outputPath = path.resolve(process.cwd(), "public", "data", "contributors-activity.json");
   const dir = path.dirname(outputPath);
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true });
   }
   try {
-    // Get token from env or fallback to gh CLI (local dev)
-    let token = process.env.GITHUB_TOKEN;
-    if (!token) {
-      try {
-        token = execSync('gh auth token', { encoding: 'utf-8' }).trim();
-      } catch { /* gh not available, will try unauthenticated */ }
-    }
-    const localApi = token
-      ? new Octokit({ auth: token })
-      : octokit;
-    // GitHub stats endpoint returns 202 while generating cache — retry up to 5x
-    let data: any = null;
-    for (let attempt = 0; attempt < 5; attempt++) {
-      const resp = await localApi.request("GET /repos/{owner}/{repo}/stats/contributors", { owner, repo });
-      if (resp.status === 200 && Array.isArray(resp.data)) {
-        data = resp.data;
-        break;
+    // Use local git log instead of GitHub API (/stats/contributors often stuck at 202)
+    // Format: %ae = author email, %at = author timestamp (unix)
+    const rawLog = execSync('git log --format="%ae %at" --since="3 months ago" --no-merges', { encoding: 'utf-8' });
+    const lines = rawLog.trim().split('\n').filter(Boolean);
+
+    // Group commits by author email, then by week
+    const emailCommits: Record<string, { w: number; c: number }[]> = {};
+    const emailTotals: Record<string, number> = {};
+
+    for (const line of lines) {
+      const [email, ts] = line.split(' ');
+      const t = parseInt(ts, 10);
+      if (!email || isNaN(t)) continue;
+      // Align to Monday of the week (GitHub uses Monday-based weeks)
+      const d = new Date(t * 1000);
+      const day = d.getDay();
+      const monOffset = day === 0 ? 6 : day - 1; // Sunday=0 -> Monday=0 offset
+      const monday = new Date(d);
+      monday.setDate(d.getDate() - monOffset);
+      monday.setHours(0, 0, 0, 0);
+      const weekTs = Math.floor(monday.getTime() / 1000);
+
+      if (!emailCommits[email]) {
+        emailCommits[email] = [];
+        emailTotals[email] = 0;
       }
-      console.log("[activity] Attempt " + (attempt + 1) + " got " + resp.status + ", retrying in 3s...");
-      await new Promise(r => setTimeout(r, 3000));
+      emailTotals[email]++;
+
+      const existing = emailCommits[email].find(w => w.w === weekTs);
+      if (existing) {
+        existing.c++;
+      } else {
+        emailCommits[email].push({ w: weekTs, c: 1 });
+      }
     }
-    if (data) {
-      const simplified = data.map((contrib: any) => ({
-        author: { login: contrib.author.login },
-        total: contrib.total,
-        weeks: contrib.weeks.map((w: any) => ({ w: w.w, c: w.c })),
-      }));
-      fs.writeFileSync(outputPath, JSON.stringify(simplified), "utf-8");
-      console.log("[activity] Saved " + simplified.length + " contributors");
-    } else {
-      console.warn("[activity] All 5 attempts failed, writing empty data");
-      fs.writeFileSync(outputPath, JSON.stringify([]), "utf-8");
+
+    // Sort weeks for each email
+    for (const email of Object.keys(emailCommits)) {
+      emailCommits[email].sort((a, b) => a.w - b.w);
     }
+
+    // Map emails to GitHub usernames and merge duplicates
+    const merged = new Map();
+    for (const [email, weeks] of Object.entries(emailCommits)) {
+      const username = emailMap[email] || email.split('@')[0];
+      if (!merged.has(username)) {
+        merged.set(username, { login: username, total: 0, weeks: new Map() });
+      }
+      const entry = merged.get(username);
+      entry.total += emailTotals[email];
+      for (const w of weeks) {
+        entry.weeks.set(w.w, (entry.weeks.get(w.w) || 0) + w.c);
+      }
+    }
+
+    // Convert merged map to result format
+    const result = [];
+    for (const entry of merged.values()) {
+      const weeksArr = [];
+      for (const [w, c] of entry.weeks) {
+        weeksArr.push({ w, c });
+      }
+      weeksArr.sort((a, b) => a.w - b.w);
+      result.push({
+        author: { login: entry.login },
+        total: entry.total,
+        weeks: weeksArr,
+      });
+    }
+
+    // Sort by total commits descending
+    result.sort((a, b) => b.total - a.total);
+
+    fs.writeFileSync(outputPath, JSON.stringify(result), "utf-8");
+    console.log("[activity] Saved " + result.length + " contributors (" + lines.length + " commits) from git log");
   } catch (error) {
     console.warn("[activity] Failed:", (error as Error).message);
-    fs.writeFileSync(outputPath, JSON.stringify([]), "utf-8");
+    try { fs.writeFileSync(outputPath, JSON.stringify([]), "utf-8"); } catch {}
   }
 }
 
@@ -293,7 +339,14 @@ export default function addContributorsPlugin(): Plugin {
       if (!dataLoaded) {
         console.log('Loading contributor data...');
         fullContributorData = await getAllContributors();
-        await fetchAndSaveActivityData();
+        // Build email→username map from contributor data
+        const emailMap: Record<string, string> = {};
+        for (const c of fullContributorData) {
+          for (const email of c.emails) {
+            emailMap[email] = c.username;
+          }
+        }
+        await fetchAndSaveActivityData(emailMap);
         dataLoaded = true;
       }
     },


### PR DESCRIPTION
## 问题

PR #99 合并后 CI 虽因 GitHub Actions 基础设施问题失败（Service Unavailable），
但底层代码仍依赖 GitHub  API——该 endpoint 不稳定，频繁返回 202。

## 修复

完全重写 ：从 GitHub API 改为本地 git log。

- execSync(git log) 读取过去 3 个月的提交历史
- 按作者邮箱 → 周聚合，多邮箱自动合并同用户
- 不再依赖 GitHub API、无需 GITHUB_TOKEN、不惧 202 超时
- 模块级 Octokit 也加上 gh auth token fallback

## 验证

本地构建 100% 通过：
[activity] Saved 3 contributors (194 commits) from git log

数据：FwindEmiko 127, FCelestial 64, star.fox 3（过去 3 个月 13 周）
