### PR TITLE
fix: GithubRepoActivity 柱状图标签缺少 {{ 导致显示 raw 模板语法

### DIFF
--- a/.vitepress/theme/components/vue/GithubRepoActivity.vue
+++ b/.vitepress/theme/components/vue/GithubRepoActivity.vue
@@ -41,7 +41,7 @@
             </div>
             <div v-else class="bar-empty"></div>
           </div>
-          <div class="bar-label"> week.shortLabel }}</div>
+          <div class="bar-label">{{ week.shortLabel }}</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 问题

图表底部日期标签显示原始 Vue 模板语法：


## 根因

模板插值  的左侧  丢失了，只有右侧 。

第 44 行：


## 修复

补上 ：


## 验证

本地构建通过。编译后的 JS 中正确渲染为 （Vue 正确编译了模板表达式）。